### PR TITLE
Update kernel.R

### DIFF
--- a/R/kernel.R
+++ b/R/kernel.R
@@ -63,7 +63,7 @@
 kernel <- function(length, scale = 1., nugget = 1e-6, name = 'sexp', prior_name = 'ga', prior_coef = NULL, bounds = NULL, nugget_est = FALSE, scale_est = FALSE, input_dim = NULL, connect = NULL) {
 
   if ( name!='sexp' & name!='matern2.5' ) stop("'name' can only be either 'sexp' or 'matern2.5'.", call. = FALSE)
-  if ( !is.null(prior_name) & prior_name!='ga"' & prior_name!='inv_ga' ) stop("The provided 'prior_name' is not supported.", call. = FALSE)
+  if ( !is.null(prior_name) & prior_name!='ga' & prior_name!='inv_ga' ) stop("The provided 'prior_name' is not supported.", call. = FALSE)
 
   if(!is.null(input_dim)){
     input_dim <- reticulate::np_array(as.integer(input_dim - 1))


### PR DESCRIPTION
Hi Deyu. This function throws an error if you try to set `"ga"` as the `prior_name` and I think this is because there is an extraneous `"` which has been removed in this PR. Just flagging because I'm playing around with custom layers and I couldn't get it to run.