### PR TITLE
Fixed update error.

### DIFF
--- a/R/update.R
+++ b/R/update.R
@@ -86,7 +86,7 @@ update.dgp <- function(object, X, Y, refit = FALSE, verb = TRUE, N = 100, ess_bu
     }
     N0 <- constructor_obj_cp$N
     constructor_obj_cp$train(N, ess_burn, disable)
-    burnin <- N0 + as.integer(0.75*N)
+    burnin <- as.integer(N0 + as.integer(0.75*N))
   } else {
     burnin <- constructor_obj_cp$burnin
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -410,7 +410,7 @@ window <- function(object, start, end = NULL, thin = 1) {
   if (end > niter) end <- niter
   idx <- start:end
   idx <- idx[idx %% thin == 0]
-  constructor_obj_cp$N <- length(idx) - 1
+  constructor_obj_cp$N <- as.integer(length(idx) - 1)
   for ( l in 1:constructor_obj_cp$n_layer ){
     n_kernel <- length(constructor_obj_cp$all_layer[[l]])
     for (k in 1:n_kernel){


### PR DESCRIPTION
Hi Deyu,

I was getting an error when trying to update and refit a DGP. The idea was that I could use a previous wave emulator to provide more informative initial values for a new wave emulator, so I read in the previous emulator and then used `update()` as follows (using a small `N` just as an example):
```
m_gp <- read("m_gp.pkl")
m_gp <- update(m_gp, X = training, Y = training_ll, B = 1, refit = TRUE, N = 5)
```
which returned
```
Updating ... done
Re-fitting:
Iteration 5: Layer 2: 100%|███████████████████████| 5/5 [00:01<00:00,  4.94it/s]
Imputing ...Error: TypeError: slice indices must be integers or None or have an __index__ method
```
I tracked the error down to the `burnin` being used in the `update()` function, and so this PR just fixes that. Then the function runs as expected.