### PR TITLE
Bug fix on if benchmarkme::get_cpu()$model_name crash

### DIFF
--- a/R/initi_py.R
+++ b/R/initi_py.R
@@ -156,7 +156,7 @@ install_dgpsi <- function(env_name, py_ver, conda_path, dgpsi_ver, reinsatll = F
   }
   if (Sys.info()[["sysname"]] == "Darwin" & Sys.info()[["machine"]] == "arm64"){
     reticulate::conda_install(envname = env_name, packages = c(dgpsi_ver, '"libblas=*=*accelerate"') , conda = conda_path, forge = TRUE, additional_install_args = c('--strict-channel-priority'))
-  } else if (grepl("Intel",benchmarkme::get_cpu()$model_name)){
+  } else if (length(benchmarkme::get_cpu()$model_name) != 0 && grepl("Intel",benchmarkme::get_cpu()$model_name)){
     reticulate::conda_install(envname = env_name, packages = c(dgpsi_ver, '"libblas=*=*mkl"') , conda = conda_path, forge = TRUE, additional_install_args = c('--strict-channel-priority') )
     reticulate::conda_install(envname = env_name, packages = c('icc_rt') , channel = c("numba"), conda = conda_path)
   } else {


### PR DESCRIPTION
`benchmarkme::get_cpu()$model_name` is `character(0)` when running `dgpsi::init_py()` in a GitHub Action running on `ubuntu-24.04-arm`.

If statement requires TRUE or FALSE, but `grepl` returns `logical(0)` and therefore crashes.

Alternatively, `grepl(...)` could be wrapped in `isTRUE(grepl(...))`, but that does not feel like good code.