### PR TITLE
Add `pip` as dependency

### DIFF
--- a/R/initi_py.R
+++ b/R/initi_py.R
@@ -45,7 +45,7 @@ init_py <- function(py_ver = NULL, dgpsi_ver = NULL, reinstall = FALSE, uninstal
     ##For devel version
     dgpsi_ver <- c('dill>=0.3.2', 'matplotlib-base>=3.2.1', 'numba >=0.51.2',
                    'numpy >=1.18.2', 'pathos >=0.2.9', 'multiprocess >=0.70.13', 'psutil >=5.8.0',
-                   'scikit-learn >=0.22.0', 'scipy >=1.4.1', 'tqdm >=4.50.2', 'tabulate >=0.8.7', 'faiss-cpu >=1.7.4', 'tbb')
+                   'scikit-learn >=0.22.0', 'scipy >=1.4.1', 'tqdm >=4.50.2', 'tabulate >=0.8.7', 'faiss-cpu >=1.7.4', 'tbb', 'pip')
     env_name <- 'dgp_si_R_2_6_0_9000'
 
     ##For release version


### PR DESCRIPTION
`pip` is required to install `dgpsi`, but is not pre-installed in custom (new) conda environments, which causes a crash when installing on a brand new conda setup